### PR TITLE
Search form bugfix

### DIFF
--- a/catalog/templates/catalog/search.html
+++ b/catalog/templates/catalog/search.html
@@ -17,7 +17,7 @@ Use the form below to narrow your TESS EB catalog search results.<br><br>
     <label for="order_by">Order by:</label>
     <select id="order_by" name="order_by">
         <option value="tic__tess_id">TESS ID</option>
-        <option value="period" selected>Period</option>
+        <option value="ephemeris__period" selected>Period</option>
         <option value="morph_coeff">Morphology</option>
         <option value="tic__ra">Right ascension</option>
         <option value="tic__dec">Declination</option>
@@ -32,7 +32,7 @@ Use the form below to narrow your TESS EB catalog search results.<br><br>
     <select id="then_order_by" name="then_order_by">
         <option value="none"></option>
         <option value="tic__tess_id">TESS ID</option>
-        <option value="period">Period</option>
+        <option value="ephemeris__period">Period</option>
         <option value="morph_coeff">Morphology</option>
         <option value="tic__ra">Right ascension</option>
         <option value="tic__dec">Declination</option>
@@ -53,11 +53,11 @@ Use the form below to narrow your TESS EB catalog search results.<br><br>
 
     <table>
         <tr>
-            <td>t<sub>0</sub> [days]</td><td><input type="number" id="bjd0_min" name="bjd0_min" value="" min="0.0" max="10000.0" step="0.001"></td><td><input type="number" id="bjd0_max" name="bjd0_max" value="" min="0.0" max="10000.0" step="0.001"></td>
+            <td>t<sub>0</sub> [days]</td><td><input type="number" id="ephemeris__bjd0_min" name="ephemeris__bjd0_min" value="" min="0.0" max="10000.0" step="0.001"></td><td><input type="number" id="ephemeris__bjd0_max" name="ephemeris__bjd0_max" value="" min="0.0" max="10000.0" step="0.001"></td>
             <td>T<sub>eff</sub> [K]</td><td><input type="number" id="tic__teff_min" name="tic__teff_min" value="" min="2000" max="100000" step="1"></td><td><input type="number" id="tic__teff_max" name="tic__teff_max" value="" min="2000" max="100000" step="1"></td>
         </tr>
         <tr>
-            <td>Period [days]</td><td><input type="number" id="period_min" name="period_min" value="" min="0" max="10000" step="0.001"></td><td><input type="number" id="period_max" name="period_max" value=""  min="0" max="10000" step="0.001"></td>
+            <td>Period [days]</td><td><input type="number" id="ephemeris__period_min" name="ephemeris__period_min" value="" min="0" max="10000" step="0.001"></td><td><input type="number" id="ephemeris__period_max" name="ephemeris__period_max" value=""  min="0" max="10000" step="0.001"></td>
             <td>log(g) [dex]</td><td><input type="number" id="tic__logg_min" name="tic__logg_min" value="" min="0.0" max="8.0" step="0.01"></td><td><input type="number" id="tic__logg_max" name="tic__logg_max" value="" min="0.0" max="8.0" step="0.01"></td>
         </tr>
         <tr>

--- a/catalog/views.py
+++ b/catalog/views.py
@@ -50,7 +50,7 @@ class MainView(ListView):
         context['link'] = '?order_by=tic'
         context['ebno'] = self.ebno
         context['page_of_EBs'] = self.paginator.get_page(self.page_num)
-        context['fields'] = ['tic__tess_id', 'sectors', 'bjd0', 'bjd0_uncert', 'period', 'period_uncert', 'morph_coeff', 'source', 'flags']
+        context['fields'] = ['tic__tess_id', 'sectors', 'ephemeris__bjd0', 'ephemeris__bjd0_uncert', 'ephemeris__period', 'ephemeris__period_uncert', 'morph_coeff', 'source', 'flags']
         return context
 
     def get_queryset(self):
@@ -118,10 +118,10 @@ class MASTExport(CSVExportView):
         'tic__pmdec',
         'tic__Tmag',
         'tic__teff',
-        'bjd0',
-        'bjd0_uncert',
-        'period',
-        'period_uncert',
+        'ephemeris__bjd0',
+        'ephemeris__bjd0_uncert',
+        'ephemeris__period',
+        'ephemeris__period_uncert',
         'morph_coeff',
         'prim_width_pf',
         'prim_depth_pf',
@@ -169,8 +169,8 @@ class SearchResultsView(ListView):
     def filter(self):
         self.fields = [
             'tic__tess_id',
-            'bjd0',
-            'period',
+            'ephemeris__bjd0',
+            'ephemeris__period',
             'morph_coeff',
             'tic__ra',
             'tic__dec',
@@ -207,7 +207,7 @@ class SearchResultsView(ListView):
         context['fields'] = self.request.GET.getlist('c')
         # if quicksearch is used, no fields will be selected; fall back:
         if len(context['fields']) == 0:
-            context['fields'] = ['tic__tess_id', 'sectors', 'bjd0', 'bjd0_uncert', 'period', 'period_uncert', 'morph_coeff', 'source', 'flags']
+            context['fields'] = ['tic__tess_id', 'sectors', 'ephemeris__bjd0', 'ephemeris__bjd0_uncert', 'ephemeris__period', 'ephemeris__period_uncert', 'morph_coeff', 'source', 'flags']
 
         return context
 


### PR DESCRIPTION
When updating the EB model in django, the fields `period` and `bjd0` were removed in favor of the one-to-one relationship with `Ephemeris`. Because of that, all bjd0* and period* fields had to be prefixed by ephemeris__. This fixes all references in the views and the search form works again.